### PR TITLE
Scaffold dashboard and time tracking pages

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,43 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Time Tracked Today</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Active Projects</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Unpaid Invoices</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16" />
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Weekly Time</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-40 w-full rounded-md bg-gray-100" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, :root {
+  height: 100%;
+}
+
+body {
+  background-color: theme('colors.gray.50');
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import { SidebarNav } from '@/components/sidebar-nav';
+
+export const metadata: Metadata = {
+  title: 'Trackwork',
+  description: 'Minimal time tracking platform',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50">
+        <div className="flex min-h-screen">
+          <SidebarNav />
+          <main className="flex-1 p-4">{children}</main>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/time/page.tsx
+++ b/app/time/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { TimerCard } from '@/components/timer-card';
+import { TimeEntryRow } from '@/components/time-entry-row';
+import { ManualTimeEntryDialog } from '@/components/manual-time-entry-dialog';
+import { Button } from '@/components/ui/button';
+import { TimeEntry } from '@/lib/types';
+
+const mockEntries: TimeEntry[] = [
+  {
+    id: '1',
+    user_id: '1',
+    project_id: '1',
+    date: '2024-01-01',
+    duration: 120,
+    description: 'Design work',
+  },
+];
+
+export default function TimePage() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <TimerCard />
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Today</h2>
+        <Button onClick={() => setOpen(true)}>+ Add Manual Entry</Button>
+      </div>
+      <div>
+        {mockEntries.map((e) => (
+          <TimeEntryRow key={e.id} entry={e} />
+        ))}
+      </div>
+      <ManualTimeEntryDialog open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/components/manual-time-entry-dialog.tsx
+++ b/components/manual-time-entry-dialog.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const schema = z.object({
+  description: z.string().min(1, 'Required'),
+  duration: z.string(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ManualTimeEntryDialog({ open, onOpenChange }: Props) {
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { description: '', duration: '' },
+  });
+
+  function onSubmit(data: FormValues) {
+    console.log(data);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add Manual Entry</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Input id="description" {...form.register('description')} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="duration">Duration (minutes)</Label>
+            <Input id="duration" type="number" {...form.register('duration')} />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { LayoutDashboard, Clock, FolderKanban, Users, FileText, BarChart2, Settings } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const items = [
+  { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/time', label: 'Time', icon: Clock },
+  { href: '/projects', label: 'Projects', icon: FolderKanban },
+  { href: '/clients', label: 'Clients', icon: Users },
+  { href: '/invoices', label: 'Invoices', icon: FileText },
+  { href: '/reports', label: 'Reports', icon: BarChart2 },
+  { href: '/settings', label: 'Settings', icon: Settings },
+];
+
+export function SidebarNav() {
+  const pathname = usePathname();
+  return (
+    <aside className="hidden w-56 flex-col border-r bg-white p-4 md:flex">
+      <nav className="flex flex-col gap-1">
+        {items.map((item) => {
+          const Icon = item.icon;
+          const active = pathname.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100',
+                active && 'bg-gray-100'
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/components/time-entry-row.tsx
+++ b/components/time-entry-row.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { TimeEntry } from '@/lib/types';
+
+interface Props {
+  entry: TimeEntry;
+}
+
+export function TimeEntryRow({ entry }: Props) {
+  return (
+    <Card className="mb-2">
+      <CardContent className="flex items-center justify-between py-4">
+        <div>
+          <p className="text-sm font-medium">{entry.description || 'No description'}</p>
+          <p className="text-xs text-gray-500">{entry.date}</p>
+        </div>
+        <p className="font-mono text-sm">{(entry.duration / 60).toFixed(2)}h</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/timer-card.tsx
+++ b/components/timer-card.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export function TimerCard() {
+  const [seconds, setSeconds] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(() => setSeconds((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [running]);
+
+  const toggle = () => setRunning((r) => !r);
+  const reset = () => {
+    setSeconds(0);
+    setRunning(false);
+  };
+
+  const time = new Date(seconds * 1000).toISOString().substring(11, 19);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Timer</CardTitle>
+      </CardHeader>
+      <CardContent className="flex items-center gap-4">
+        <select className="h-9 rounded-md border px-2 py-1">
+          <option>Select project</option>
+        </select>
+        <div className="w-24 font-mono text-2xl">{time}</div>
+        <Button onClick={toggle}>{running ? 'Stop' : 'Start'}</Button>
+        <Button variant="ghost" onClick={reset}>
+          Reset
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline' | 'ghost';
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    const variantClasses =
+      variant === 'outline'
+        ? 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
+        : variant === 'ghost'
+        ? 'hover:bg-accent hover:text-accent-foreground'
+        : 'bg-primary text-primary-foreground hover:bg-primary/90';
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 h-9 px-4 py-2',
+          variantClasses,
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('rounded-2xl border bg-white text-gray-950 shadow-sm', className)} {...props} />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 border-b', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-lg font-semibold leading-none', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+export { Card, CardHeader, CardTitle, CardContent };

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function Dialog({ open, onOpenChange, children }: DialogProps) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={() => onOpenChange(false)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DialogContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('w-full max-w-md rounded-2xl bg-white p-6 shadow-lg', className)}
+      onClick={(e) => e.stopPropagation()}
+      {...props}
+    />
+  );
+}
+
+export function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mb-4', className)} {...props} />;
+}
+
+export function DialogTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h2 className={cn('text-lg font-semibold', className)} {...props} />;
+}
+
+export function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-4 flex justify-end gap-2', className)} {...props} />;
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('text-sm font-medium text-gray-700', className)}
+      {...props}
+    />
+  )
+);
+Label.displayName = 'Label';
+
+export { Label };

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,5 @@
+import { cn } from '@/lib/utils';
+
+export function Skeleton({ className }: { className?: string }) {
+  return <div className={cn('animate-pulse rounded-md bg-gray-200', className)} />;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,46 @@
+export interface User {
+  id: string;
+  email: string;
+  full_name: string | null;
+  role: string;
+}
+
+export interface Client {
+  id: string;
+  name: string;
+  email: string | null;
+  company_name: string | null;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  client_id: string;
+  budget_hours: number | null;
+  is_active: boolean;
+}
+
+export interface TimeEntry {
+  id: string;
+  user_id: string;
+  project_id: string;
+  date: string; // ISO date
+  duration: number; // minutes
+  description: string | null;
+}
+
+export interface Invoice {
+  id: string;
+  client_id: string;
+  date: string; // ISO date
+  total_amount: number;
+  status: string;
+}
+
+export interface InvoiceItem {
+  id: string;
+  invoice_id: string;
+  description: string;
+  hours: number;
+  rate: number;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]) {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add root layout with sidebar navigation
- scaffold dashboard with metric cards and weekly time placeholder
- add time tracking page with live timer and manual entry dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ebd69cdc8325b05b93aa11853128