### PR TITLE
Fix GitHub Pages 404 by adding root landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+      <h1 className="text-2xl font-bold">Welcome to Trackwork</h1>
+      <p className="text-gray-600">A minimal time tracking platform.</p>
+      <Link href="/dashboard" className="text-blue-500 hover:underline">
+        Go to Dashboard
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add HomePage at `/` that links to the dashboard

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b6ee1c024483259808499daed01fab