### PR TITLE
Fix GitHub Pages 404 with static index

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+      <h1 className="text-2xl font-bold">Welcome to Trackwork</h1>
+      <p className="text-gray-600">A minimal time tracking platform.</p>
+      <Link href="/dashboard" className="text-blue-500 hover:underline">
+        Go to Dashboard
+      </Link>
+    </div>
+  );
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Trackwork Dashboard</title>
+  </head>
+  <body style="font-family: sans-serif; padding: 1rem;">
+    <h1>Dashboard</h1>
+    <p>Content coming soon.</p>
+    <p><a href="../">Back to Home</a></p>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Trackwork</title>
+  </head>
+  <body style="font-family: sans-serif;
+               display: flex;
+               flex-direction: column;
+               align-items: center;
+               justify-content: center;
+               min-height: 100vh;
+               text-align: center;">
+    <h1>Welcome to Trackwork</h1>
+    <p>A minimal time tracking platform.</p>
+    <p><a href="dashboard/">Go to Dashboard</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add static `index.html` linking to dashboard so GitHub Pages serves a landing page
- include basic `dashboard/index.html` placeholder to avoid further 404s

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b6ee1c024483259808499daed01fab