### PR TITLE
feat: add responsive dashboard shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,5 +7,5 @@ html, body, :root {
 }
 
 body {
-  background-color: theme('colors.gray.50');
+  @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-50;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import { SidebarNav } from '@/components/sidebar-nav';
+import { Sidebar } from '@/components/ui/sidebar';
+import { Header } from '@/components/ui/header';
 
 export const metadata: Metadata = {
   title: 'Trackwork',
@@ -9,11 +10,14 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-gray-50">
+    <html lang="en" className="h-full">
+      <body className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-50">
         <div className="flex min-h-screen">
-          <SidebarNav />
-          <main className="flex-1 p-4">{children}</main>
+          <Sidebar className="hidden md:flex" />
+          <div className="flex flex-1 flex-col">
+            <Header />
+            <main className="flex-1 p-4">{children}</main>
+          </div>
         </div>
       </body>
     </html>

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Avatar = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn('relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full', className)}
+      {...props}
+    />
+  )
+);
+Avatar.displayName = 'Avatar';
+
+const AvatarImage = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<HTMLImageElement>>(
+  ({ className, ...props }, ref) => (
+    <img ref={ref} className={cn('aspect-square h-full w-full', className)} {...props} />
+  )
+);
+AvatarImage.displayName = 'AvatarImage';
+
+const AvatarFallback = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        'flex h-full w-full items-center justify-center rounded-full bg-gray-100 text-sm font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+AvatarFallback.displayName = 'AvatarFallback';
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface DropdownContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const DropdownContext = React.createContext<DropdownContextValue | undefined>(undefined);
+
+export function DropdownMenu({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <DropdownContext.Provider value={{ open, setOpen }}>
+      <div className="relative">{children}</div>
+    </DropdownContext.Provider>
+  );
+}
+
+export function DropdownMenuTrigger({
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const context = React.useContext(DropdownContext);
+  if (!context) throw new Error('DropdownMenuTrigger must be used within DropdownMenu');
+  const { open, setOpen } = context;
+  return (
+    <button
+      className={className}
+      onClick={() => setOpen(!open)}
+      {...props}
+    />
+  );
+}
+
+export function DropdownMenuContent({
+  className,
+  children,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  const context = React.useContext(DropdownContext);
+  if (!context) throw new Error('DropdownMenuContent must be used within DropdownMenu');
+  const { open, setOpen } = context;
+  if (!open) return null;
+  return (
+    <div
+      className={cn(
+        'absolute right-0 mt-2 w-40 rounded-md border bg-white p-1 shadow-md dark:border-gray-800 dark:bg-gray-950',
+        className
+      )}
+      onClick={() => setOpen(false)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DropdownMenuItem({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  const context = React.useContext(DropdownContext);
+  if (!context) throw new Error('DropdownMenuItem must be used within DropdownMenu');
+  const { setOpen } = context;
+  return (
+    <div
+      className={cn(
+        'cursor-pointer rounded-sm px-2 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-800',
+        className
+      )}
+      onClick={() => setOpen(false)}
+      {...props}
+    />
+  );
+}

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import * as React from 'react';
+import { Menu } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Sidebar } from '@/components/ui/sidebar';
+
+export function Header() {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <header className="flex h-14 items-center border-b bg-white px-4 dark:border-gray-800 dark:bg-gray-950">
+      <Button variant="ghost" className="mr-2 md:hidden" onClick={() => setOpen(true)}>
+        <Menu className="h-5 w-5" />
+        <span className="sr-only">Toggle menu</span>
+      </Button>
+      <div className="ml-auto flex items-center gap-4">
+      <DropdownMenu>
+        <DropdownMenuTrigger className="rounded-full">
+          <Avatar>
+            <AvatarFallback>U</AvatarFallback>
+          </Avatar>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Profile</DropdownMenuItem>
+          <DropdownMenuItem>Settings</DropdownMenuItem>
+          <DropdownMenuItem>Logout</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      </div>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="left" className="p-0">
+          <Sidebar onNavigate={() => setOpen(false)} />
+        </SheetContent>
+      </Sheet>
+    </header>
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface SheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function Sheet({ open, onOpenChange, children }: SheetProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/50" onClick={() => onOpenChange(false)} />
+      {children}
+    </div>
+  );
+}
+
+interface SheetContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  side?: 'left' | 'right';
+}
+
+export function SheetContent({
+  side = 'left',
+  className,
+  ...props
+}: SheetContentProps) {
+  return (
+    <div
+      className={cn(
+        'absolute top-0 h-full w-64 bg-white p-4 shadow-lg dark:bg-gray-950',
+        side === 'left' ? 'left-0' : 'right-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -2,7 +2,15 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Clock, FolderKanban, Users, FileText, BarChart2, Settings } from 'lucide-react';
+import {
+  LayoutDashboard,
+  Clock,
+  FolderKanban,
+  Users,
+  FileText,
+  BarChart2,
+  Settings,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const items = [
@@ -15,10 +23,20 @@ const items = [
   { href: '/settings', label: 'Settings', icon: Settings },
 ];
 
-export function SidebarNav() {
+interface SidebarProps {
+  className?: string;
+  onNavigate?: () => void;
+}
+
+export function Sidebar({ className, onNavigate }: SidebarProps) {
   const pathname = usePathname();
   return (
-    <aside className="hidden w-56 flex-col border-r bg-white p-4 md:flex">
+    <aside
+      className={cn(
+        'flex w-56 flex-col border-r bg-white p-4 dark:border-gray-800 dark:bg-gray-950',
+        className
+      )}
+    >
       <nav className="flex flex-col gap-1">
         {items.map((item) => {
           const Icon = item.icon;
@@ -28,9 +46,10 @@ export function SidebarNav() {
               key={item.href}
               href={item.href}
               className={cn(
-                'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100',
-                active && 'bg-gray-100'
+                'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800',
+                active && 'bg-gray-100 dark:bg-gray-800'
               )}
+              onClick={onNavigate}
             >
               <Icon className="h-4 w-4" />
               {item.label}


### PR DESCRIPTION
## Summary
- add sidebar and header components
- implement mobile drawer and profile dropdown
- prepare global styles for dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fbeab4688325816c41da411f81f6