### PR TITLE
Add clients table page and fix navigation

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+const clients = [
+  {
+    name: 'Acme Corp',
+    contact: 'John Doe',
+    email: 'john@example.com',
+    phone: '(123) 456-7890',
+    project: 'project-alpha',
+    projectName: 'Project Alpha',
+  },
+  {
+    name: 'Globex Inc',
+    contact: 'Jane Smith',
+    email: 'jane@example.com',
+    phone: '(987) 654-3210',
+    project: 'project-beta',
+    projectName: 'Project Beta',
+  },
+];
+
+export default function ClientsPage() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Client List</h1>
+        <Button>Create a new client</Button>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[200px]">Name</TableHead>
+            <TableHead>Contact Person</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Phone</TableHead>
+            <TableHead>Linked Project</TableHead>
+            <TableHead>Client Number</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {clients.map((client, index) => (
+            <TableRow key={client.email}>
+              <TableCell className="font-medium">{client.name}</TableCell>
+              <TableCell>{client.contact}</TableCell>
+              <TableCell>{client.email}</TableCell>
+              <TableCell>{client.phone}</TableCell>
+              <TableCell>
+                <Link href={`/projects/${client.project}`}>{client.projectName}</Link>
+              </TableCell>
+              <TableCell>{String(index + 1).padStart(3, '0')}</TableCell>
+              <TableCell className="text-right">
+                <Button variant="outline">Edit</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/clients/index.html
+++ b/clients/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Client List - Trackwork</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+  </head>
+  <body class="h-full bg-gray-50 text-gray-900">
+    <div class="flex min-h-screen">
+      <aside id="sidebar" class="hidden md:flex w-56 flex-col border-r bg-white p-4">
+        <nav class="flex flex-col gap-1">
+          <a href="../dashboard/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="layout-dashboard" class="h-4 w-4"></i>
+            Dashboard
+          </a>
+          <a href="../time/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="clock" class="h-4 w-4"></i>
+            Time
+          </a>
+          <a href="../projects/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="folder-kanban" class="h-4 w-4"></i>
+            Projects
+          </a>
+          <a href="../clients/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100 bg-gray-100">
+            <i data-lucide="users" class="h-4 w-4"></i>
+            Clients
+          </a>
+          <a href="../invoices/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="file-text" class="h-4 w-4"></i>
+            Invoices
+          </a>
+          <a href="../reports/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="bar-chart-2" class="h-4 w-4"></i>
+            Reports
+          </a>
+          <a href="../settings/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="settings" class="h-4 w-4"></i>
+            Settings
+          </a>
+        </nav>
+      </aside>
+      <div class="flex flex-1 flex-col">
+        <header class="flex h-14 items-center border-b bg-white px-4">
+          <button id="menuButton" class="mr-2 md:hidden">
+            <i data-lucide="menu" class="h-5 w-5"></i>
+            <span class="sr-only">Toggle menu</span>
+          </button>
+          <h1 class="text-xl font-semibold">Clients</h1>
+          <a href="#" class="ml-auto inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new client</a>
+        </header>
+        <main class="flex-1 p-4 space-y-4">
+          <div class="w-full overflow-auto">
+            <table class="w-full caption-bottom text-sm">
+              <thead class="[&_tr]:border-b">
+                <tr>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Name</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Contact Person</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Email</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Phone</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Linked Project</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Client Number</th>
+                  <th class="h-10 px-2 text-right align-middle font-medium text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody class="[&_tr:last-child]:border-0">
+                <tr class="border-b">
+                  <td class="p-2 align-middle font-medium">Acme Corp</td>
+                  <td class="p-2 align-middle">John Doe</td>
+                  <td class="p-2 align-middle">john@example.com</td>
+                  <td class="p-2 align-middle">(123) 456-7890</td>
+                  <td class="p-2 align-middle"><a href="../projects/project-alpha" class="text-blue-600 hover:underline">Project Alpha</a></td>
+                  <td class="p-2 align-middle">001</td>
+                  <td class="p-2 align-middle text-right"><button class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</button></td>
+                </tr>
+                <tr class="border-b">
+                  <td class="p-2 align-middle font-medium">Globex Inc</td>
+                  <td class="p-2 align-middle">Jane Smith</td>
+                  <td class="p-2 align-middle">jane@example.com</td>
+                  <td class="p-2 align-middle">(987) 654-3210</td>
+                  <td class="p-2 align-middle"><a href="../projects/project-beta" class="text-blue-600 hover:underline">Project Beta</a></td>
+                  <td class="p-2 align-middle">002</td>
+                  <td class="p-2 align-middle text-right"><button class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p><a href="../" class="text-blue-600 underline">Back to Home</a></p>
+        </main>
+      </div>
+    </div>
+    <script>
+      lucide.createIcons();
+      const menuBtn = document.getElementById('menuButton');
+      const sidebar = document.getElementById('sidebar');
+      menuBtn.addEventListener('click', () => {
+        sidebar.classList.toggle('hidden');
+      });
+    </script>
+  </body>
+</html>

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+  )
+);
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+  )
+);
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot
+      ref={ref}
+      className={cn('bg-gray-50 font-medium text-gray-900 dark:bg-gray-800 dark:text-gray-50', className)}
+      {...props}
+    />
+  )
+);
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b transition-colors hover:bg-gray-100/50 data-[state=selected]:bg-gray-100 dark:hover:bg-gray-800/50 dark:data-[state=selected]:bg-gray-800',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn(
+        'h-10 px-2 text-left align-middle font-medium text-gray-500 dark:text-gray-400 [&:has([role=checkbox])]:pr-0',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0', className)} {...props} />
+  )
+);
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption ref={ref} className={cn('mt-4 text-sm text-gray-500 dark:text-gray-400', className)} {...props} />
+  )
+);
+TableCaption.displayName = 'TableCaption';
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -11,31 +11,31 @@
     <div class="flex min-h-screen">
       <aside id="sidebar" class="hidden md:flex w-56 flex-col border-r bg-white p-4">
         <nav class="flex flex-col gap-1">
-          <a href="/dashboard" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../dashboard/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100 bg-gray-100">
             <i data-lucide="layout-dashboard" class="h-4 w-4"></i>
             Dashboard
           </a>
-          <a href="/time" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../time/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
             <i data-lucide="clock" class="h-4 w-4"></i>
             Time
           </a>
-          <a href="/projects" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../projects/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
             <i data-lucide="folder-kanban" class="h-4 w-4"></i>
             Projects
           </a>
-          <a href="/clients" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../clients/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
             <i data-lucide="users" class="h-4 w-4"></i>
             Clients
           </a>
-          <a href="/invoices" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../invoices/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
             <i data-lucide="file-text" class="h-4 w-4"></i>
             Invoices
           </a>
-          <a href="/reports" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../reports/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
             <i data-lucide="bar-chart-2" class="h-4 w-4"></i>
             Reports
           </a>
-          <a href="/settings" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+          <a href="../settings/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
             <i data-lucide="settings" class="h-4 w-4"></i>
             Settings
           </a>


### PR DESCRIPTION
## Summary
- add static clients list page with sample table and create-client button
- make dashboard sidebar use relative links so Clients link works

## Testing
- npm test (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bb8cab97b48325aed573e4b50e2913