### PR TITLE
feat: add client editing page

### DIFF
--- a/app/clients/[id]/edit/page.tsx
+++ b/app/clients/[id]/edit/page.tsx
@@ -1,0 +1,73 @@
+import { clients } from '@/lib/clients';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+interface Props {
+  params: { id: string };
+}
+
+export default function EditClientPage({ params }: Props) {
+  const client = clients.find((c) => c.id === params.id);
+  if (!client) {
+    return <p>Client not found.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Edit Client</h1>
+      <form className="space-y-4 max-w-md">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" defaultValue={client.name} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="contact">Contact Person</Label>
+          <Input id="contact" defaultValue={client.contact} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            defaultValue={client.email}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="phone">Phone</Label>
+          <Input
+            id="phone"
+            type="tel"
+            inputMode="tel"
+            pattern="\\(\\d{3}\\) \\d{3}-\\d{4}"
+            defaultValue={client.phone}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="project">Linked Project</Label>
+          <Input id="project" defaultValue={client.projectName} required />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="clientNumber">Client Number</Label>
+          <Input
+            id="clientNumber"
+            type="text"
+            inputMode="numeric"
+            pattern="\\d{3}"
+            defaultValue={client.clientNumber}
+            required
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button type="submit">Save</Button>
+          <Link href="/clients" className="text-sm text-blue-600 underline">
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { Button } from '@/components/ui/button';
 import {
   Table,
   TableBody,
@@ -8,25 +7,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-
-const clients = [
-  {
-    name: 'Acme Corp',
-    contact: 'John Doe',
-    email: 'john@example.com',
-    phone: '(123) 456-7890',
-    project: 'project-alpha',
-    projectName: 'Project Alpha',
-  },
-  {
-    name: 'Globex Inc',
-    contact: 'Jane Smith',
-    email: 'jane@example.com',
-    phone: '(987) 654-3210',
-    project: 'project-beta',
-    projectName: 'Project Beta',
-  },
-];
+import { Button } from '@/components/ui/button';
+import { clients } from '@/lib/clients';
 
 export default function ClientsPage() {
   return (
@@ -48,8 +30,8 @@ export default function ClientsPage() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {clients.map((client, index) => (
-            <TableRow key={client.email}>
+          {clients.map((client) => (
+            <TableRow key={client.id}>
               <TableCell className="font-medium">{client.name}</TableCell>
               <TableCell>{client.contact}</TableCell>
               <TableCell>{client.email}</TableCell>
@@ -57,9 +39,14 @@ export default function ClientsPage() {
               <TableCell>
                 <Link href={`/projects/${client.project}`}>{client.projectName}</Link>
               </TableCell>
-              <TableCell>{String(index + 1).padStart(3, '0')}</TableCell>
+              <TableCell>{client.clientNumber}</TableCell>
               <TableCell className="text-right">
-                <Button variant="outline">Edit</Button>
+                <Link
+                  href={`/clients/${client.id}/edit`}
+                  className="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50"
+                >
+                  Edit
+                </Link>
               </TableCell>
             </TableRow>
           ))}

--- a/clients/edit.html
+++ b/clients/edit.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Edit Client - Trackwork</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+  </head>
+  <body class="h-full bg-gray-50 text-gray-900">
+    <div class="flex min-h-screen">
+      <aside id="sidebar" class="hidden md:flex w-56 flex-col border-r bg-white p-4">
+        <nav class="flex flex-col gap-1">
+          <a href="../dashboard/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="layout-dashboard" class="h-4 w-4"></i>
+            Dashboard
+          </a>
+          <a href="../time/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="clock" class="h-4 w-4"></i>
+            Time
+          </a>
+          <a href="../projects/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="folder-kanban" class="h-4 w-4"></i>
+            Projects
+          </a>
+          <a href="../clients/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100 bg-gray-100">
+            <i data-lucide="users" class="h-4 w-4"></i>
+            Clients
+          </a>
+          <a href="../invoices/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="file-text" class="h-4 w-4"></i>
+            Invoices
+          </a>
+          <a href="../reports/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="bar-chart-2" class="h-4 w-4"></i>
+            Reports
+          </a>
+          <a href="../settings/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="settings" class="h-4 w-4"></i>
+            Settings
+          </a>
+        </nav>
+      </aside>
+      <div class="flex flex-1 flex-col">
+        <header class="flex h-14 items-center border-b bg-white px-4">
+          <button id="menuButton" class="mr-2 md:hidden">
+            <i data-lucide="menu" class="h-5 w-5"></i>
+            <span class="sr-only">Toggle menu</span>
+          </button>
+          <h1 class="text-xl font-semibold">Edit Client</h1>
+        </header>
+        <main class="flex-1 p-4 space-y-4">
+          <form class="space-y-4 max-w-md">
+            <div class="space-y-2">
+              <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+              <input id="name" type="text" required class="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1" />
+            </div>
+            <div class="space-y-2">
+              <label for="contact" class="block text-sm font-medium text-gray-700">Contact Person</label>
+              <input id="contact" type="text" required class="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1" />
+            </div>
+            <div class="space-y-2">
+              <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+              <input id="email" type="email" required class="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1" />
+            </div>
+            <div class="space-y-2">
+              <label for="phone" class="block text-sm font-medium text-gray-700">Phone</label>
+              <input id="phone" type="tel" inputmode="tel" pattern="\(\d{3}\) \d{3}-\d{4}" placeholder="(123) 456-7890" required class="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1" />
+            </div>
+            <div class="space-y-2">
+              <label for="project" class="block text-sm font-medium text-gray-700">Linked Project</label>
+              <input id="project" type="text" required class="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1" />
+            </div>
+            <div class="space-y-2">
+              <label for="clientNumber" class="block text-sm font-medium text-gray-700">Client Number</label>
+              <input id="clientNumber" type="text" inputmode="numeric" pattern="\d{3}" required class="flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1" />
+            </div>
+            <button type="submit" class="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Save</button>
+          </form>
+          <p><a href="./" class="text-blue-600 underline">Back to Clients</a></p>
+        </main>
+      </div>
+    </div>
+    <script>
+      lucide.createIcons();
+      const menuBtn = document.getElementById('menuButton');
+      const sidebar = document.getElementById('sidebar');
+      menuBtn.addEventListener('click', () => {
+        sidebar.classList.toggle('hidden');
+      });
+    </script>
+  </body>
+</html>

--- a/clients/index.html
+++ b/clients/index.html
@@ -72,7 +72,7 @@
                   <td class="p-2 align-middle">(123) 456-7890</td>
                   <td class="p-2 align-middle"><a href="../projects/project-alpha" class="text-blue-600 hover:underline">Project Alpha</a></td>
                   <td class="p-2 align-middle">001</td>
-                  <td class="p-2 align-middle text-right"><button class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</button></td>
+                  <td class="p-2 align-middle text-right"><a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a></td>
                 </tr>
                 <tr class="border-b">
                   <td class="p-2 align-middle font-medium">Globex Inc</td>
@@ -81,7 +81,7 @@
                   <td class="p-2 align-middle">(987) 654-3210</td>
                   <td class="p-2 align-middle"><a href="../projects/project-beta" class="text-blue-600 hover:underline">Project Beta</a></td>
                   <td class="p-2 align-middle">002</td>
-                  <td class="p-2 align-middle text-right"><button class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</button></td>
+                  <td class="p-2 align-middle text-right"><a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a></td>
                 </tr>
               </tbody>
             </table>

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -1,0 +1,33 @@
+export interface ClientData {
+  id: string;
+  name: string;
+  contact: string;
+  email: string;
+  phone: string;
+  project: string;
+  projectName: string;
+  clientNumber: string;
+}
+
+export const clients: ClientData[] = [
+  {
+    id: '1',
+    name: 'Acme Corp',
+    contact: 'John Doe',
+    email: 'john@example.com',
+    phone: '(123) 456-7890',
+    project: 'project-alpha',
+    projectName: 'Project Alpha',
+    clientNumber: '001',
+  },
+  {
+    id: '2',
+    name: 'Globex Inc',
+    contact: 'Jane Smith',
+    email: 'jane@example.com',
+    phone: '(987) 654-3210',
+    project: 'project-beta',
+    projectName: 'Project Beta',
+    clientNumber: '002',
+  },
+];


### PR DESCRIPTION
## Summary
- add shared client data and dynamic edit route
- link client list to edit view and expose form with validation
- add static edit page and connect to list

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc41f447b08325bcfff20c0a261601