### PR TITLE
Only show essential client columns on mobile

### DIFF
--- a/clients/index.html
+++ b/clients/index.html
@@ -57,10 +57,10 @@
                 <tr>
                   <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Name</th>
                   <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Contact Person</th>
-                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Email</th>
-                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Phone</th>
-                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Linked Project</th>
-                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500">Client Number</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500 hidden md:table-cell">Email</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500 hidden md:table-cell">Phone</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500 hidden md:table-cell">Linked Project</th>
+                  <th class="h-10 px-2 text-left align-middle font-medium text-gray-500 hidden md:table-cell">Client Number</th>
                   <th class="h-10 px-2 text-right align-middle font-medium text-gray-500">Actions</th>
                 </tr>
               </thead>
@@ -68,19 +68,19 @@
                 <tr class="border-b">
                   <td class="p-2 align-middle font-medium">Acme Corp</td>
                   <td class="p-2 align-middle">John Doe</td>
-                  <td class="p-2 align-middle">john@example.com</td>
-                  <td class="p-2 align-middle">(123) 456-7890</td>
-                  <td class="p-2 align-middle"><a href="../projects/project-alpha" class="text-blue-600 hover:underline">Project Alpha</a></td>
-                  <td class="p-2 align-middle">001</td>
+                    <td class="p-2 align-middle hidden md:table-cell">john@example.com</td>
+                    <td class="p-2 align-middle hidden md:table-cell">(123) 456-7890</td>
+                    <td class="p-2 align-middle hidden md:table-cell"><a href="../projects/project-alpha" class="text-blue-600 hover:underline">Project Alpha</a></td>
+                    <td class="p-2 align-middle hidden md:table-cell">001</td>
                   <td class="p-2 align-middle text-right"><a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a></td>
                 </tr>
                 <tr class="border-b">
                   <td class="p-2 align-middle font-medium">Globex Inc</td>
                   <td class="p-2 align-middle">Jane Smith</td>
-                  <td class="p-2 align-middle">jane@example.com</td>
-                  <td class="p-2 align-middle">(987) 654-3210</td>
-                  <td class="p-2 align-middle"><a href="../projects/project-beta" class="text-blue-600 hover:underline">Project Beta</a></td>
-                  <td class="p-2 align-middle">002</td>
+                    <td class="p-2 align-middle hidden md:table-cell">jane@example.com</td>
+                    <td class="p-2 align-middle hidden md:table-cell">(987) 654-3210</td>
+                    <td class="p-2 align-middle hidden md:table-cell"><a href="../projects/project-beta" class="text-blue-600 hover:underline">Project Beta</a></td>
+                    <td class="p-2 align-middle hidden md:table-cell">002</td>
                   <td class="p-2 align-middle text-right"><a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a></td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## Summary
- Hide email, phone, linked project, and client number columns on small screens
- Keep edit action visible so only name, contact person and edit button show on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx eslint clients/index.html` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4858c6f48325a96f0e3fb7a3900c