### PR TITLE
Add client detail view and see button

### DIFF
--- a/clients/detail.html
+++ b/clients/detail.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Client Details - Trackwork</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+  </head>
+  <body class="h-full bg-gray-50 text-gray-900">
+    <div class="flex min-h-screen">
+      <aside id="sidebar" class="hidden md:flex w-56 flex-col border-r bg-white p-4">
+        <nav class="flex flex-col gap-1">
+          <a href="../dashboard/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="layout-dashboard" class="h-4 w-4"></i>
+            Dashboard
+          </a>
+          <a href="../time/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="clock" class="h-4 w-4"></i>
+            Time
+          </a>
+          <a href="../projects/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="folder-kanban" class="h-4 w-4"></i>
+            Projects
+          </a>
+          <a href="../clients/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100 bg-gray-100">
+            <i data-lucide="users" class="h-4 w-4"></i>
+            Clients
+          </a>
+          <a href="../invoices/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="file-text" class="h-4 w-4"></i>
+            Invoices
+          </a>
+          <a href="../reports/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="bar-chart-2" class="h-4 w-4"></i>
+            Reports
+          </a>
+          <a href="../settings/" class="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-100">
+            <i data-lucide="settings" class="h-4 w-4"></i>
+            Settings
+          </a>
+        </nav>
+      </aside>
+      <div class="flex flex-1 flex-col">
+        <header class="flex h-14 items-center border-b bg-white px-4">
+          <button id="menuButton" class="mr-2 md:hidden">
+            <i data-lucide="menu" class="h-5 w-5"></i>
+            <span class="sr-only">Toggle menu</span>
+          </button>
+          <h1 class="text-xl font-semibold">Client Details</h1>
+        </header>
+        <main class="flex-1 p-4 space-y-4">
+          <div class="space-y-2 max-w-md">
+            <h2 class="text-lg font-semibold">Acme Corp</h2>
+            <p><span class="font-medium">Contact Person:</span> John Doe</p>
+            <p><span class="font-medium">Email:</span> john@example.com</p>
+            <p><span class="font-medium">Phone:</span> (123) 456-7890</p>
+            <p><span class="font-medium">Linked Project:</span> <a href="../projects/project-alpha" class="text-blue-600 hover:underline">Project Alpha</a></p>
+            <p><span class="font-medium">Client Number:</span> 001</p>
+            <a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a>
+          </div>
+          <p><a href="./" class="text-blue-600 underline">Back to Clients</a></p>
+        </main>
+      </div>
+    </div>
+    <script>
+      lucide.createIcons();
+      const menuBtn = document.getElementById('menuButton');
+      const sidebar = document.getElementById('sidebar');
+      menuBtn.addEventListener('click', () => {
+        sidebar.classList.toggle('hidden');
+      });
+    </script>
+  </body>
+</html>

--- a/clients/index.html
+++ b/clients/index.html
@@ -72,7 +72,7 @@
                     <td class="p-2 align-middle hidden md:table-cell">(123) 456-7890</td>
                     <td class="p-2 align-middle hidden md:table-cell"><a href="../projects/project-alpha" class="text-blue-600 hover:underline">Project Alpha</a></td>
                     <td class="p-2 align-middle hidden md:table-cell">001</td>
-                  <td class="p-2 align-middle text-right"><a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a></td>
+                  <td class="p-2 align-middle text-right"><a href="detail.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">See</a></td>
                 </tr>
                 <tr class="border-b">
                   <td class="p-2 align-middle font-medium">Globex Inc</td>
@@ -81,7 +81,7 @@
                     <td class="p-2 align-middle hidden md:table-cell">(987) 654-3210</td>
                     <td class="p-2 align-middle hidden md:table-cell"><a href="../projects/project-beta" class="text-blue-600 hover:underline">Project Beta</a></td>
                     <td class="p-2 align-middle hidden md:table-cell">002</td>
-                  <td class="p-2 align-middle text-right"><a href="edit.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">Edit</a></td>
+                  <td class="p-2 align-middle text-right"><a href="detail.html" class="inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-medium hover:bg-gray-50">See</a></td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
- add client details page with an edit option
- replace edit actions in client list with see link to details

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ed926748325b5e252e75ab1bb63