### PR TITLE
feat: add user avatar to headers

### DIFF
--- a/clients/detail.html
+++ b/clients/detail.html
@@ -48,6 +48,9 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <h1 class="text-xl font-semibold">Client Details</h1>
+          <div class="ml-auto flex items-center gap-6">
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4 space-y-4">
           <div class="space-y-2 max-w-md">

--- a/clients/edit.html
+++ b/clients/edit.html
@@ -48,6 +48,9 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <h1 class="text-xl font-semibold">Edit Client</h1>
+          <div class="ml-auto flex items-center gap-6">
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4 space-y-4">
           <form class="space-y-4 max-w-md">

--- a/clients/index.html
+++ b/clients/index.html
@@ -48,7 +48,10 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <h1 class="text-xl font-semibold">Clients</h1>
-          <a href="#" class="ml-auto inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new client</a>
+          <div class="ml-auto flex items-center gap-6">
+            <a href="#" class="inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new client</a>
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4 space-y-4">
           <div class="w-full overflow-auto">

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -21,19 +21,19 @@ export function Header() {
         <Menu className="h-5 w-5" />
         <span className="sr-only">Toggle menu</span>
       </Button>
-      <div className="ml-auto flex items-center gap-4">
-      <DropdownMenu>
-        <DropdownMenuTrigger className="rounded-full">
-          <Avatar>
-            <AvatarFallback>U</AvatarFallback>
-          </Avatar>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuItem>Profile</DropdownMenuItem>
-          <DropdownMenuItem>Settings</DropdownMenuItem>
-          <DropdownMenuItem>Logout</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="ml-auto flex items-center gap-6">
+        <DropdownMenu>
+          <DropdownMenuTrigger className="rounded-full">
+            <Avatar>
+              <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Profile</DropdownMenuItem>
+            <DropdownMenuItem>Settings</DropdownMenuItem>
+            <DropdownMenuItem>Logout</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
       <Sheet open={open} onOpenChange={setOpen}>
         <SheetContent side="left" className="p-0">

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -47,7 +47,9 @@
             <i data-lucide="menu" class="h-5 w-5"></i>
             <span class="sr-only">Toggle menu</span>
           </button>
-          <div class="ml-auto h-8 w-8 rounded-full bg-gray-300"></div>
+          <div class="ml-auto flex items-center gap-6">
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4">
           <h1 class="mb-4 text-xl font-semibold">Dashboard</h1>

--- a/projects/detail.html
+++ b/projects/detail.html
@@ -48,6 +48,9 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <h1 class="text-xl font-semibold">Project Details</h1>
+          <div class="ml-auto flex items-center gap-6">
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4 space-y-4">
           <div class="space-y-2 max-w-md">

--- a/projects/edit.html
+++ b/projects/edit.html
@@ -48,6 +48,9 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <h1 class="text-xl font-semibold">Edit Project</h1>
+          <div class="ml-auto flex items-center gap-6">
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4 space-y-4">
           <form class="space-y-4 max-w-md">

--- a/projects/index.html
+++ b/projects/index.html
@@ -48,7 +48,10 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <h1 class="text-xl font-semibold">Projects</h1>
-          <a href="#" class="ml-auto inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new project</a>
+          <div class="ml-auto flex items-center gap-6">
+            <a href="#" class="inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new project</a>
+            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+          </div>
         </header>
         <main class="flex-1 p-4 space-y-4">
           <div class="w-full overflow-auto">


### PR DESCRIPTION
## Summary
- show placeholder user avatar in top right header with 24px spacing
- include avatar on static dashboard, client, and project pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beed3ab47c8325bc11b76d30ceced6