### PR TITLE
feat: use Shadcn avatar with custom color

### DIFF
--- a/clients/detail.html
+++ b/clients/detail.html
@@ -49,7 +49,11 @@
           </button>
           <h1 class="text-xl font-semibold">Client Details</h1>
           <div class="ml-auto flex items-center gap-6">
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4 space-y-4">

--- a/clients/edit.html
+++ b/clients/edit.html
@@ -49,7 +49,11 @@
           </button>
           <h1 class="text-xl font-semibold">Edit Client</h1>
           <div class="ml-auto flex items-center gap-6">
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4 space-y-4">

--- a/clients/index.html
+++ b/clients/index.html
@@ -50,7 +50,11 @@
           <h1 class="text-xl font-semibold">Clients</h1>
           <div class="ml-auto flex items-center gap-6">
             <a href="#" class="inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new client</a>
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4 space-y-4">

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -21,10 +21,14 @@ const AvatarImage = React.forwardRef<HTMLImageElement, React.ImgHTMLAttributes<H
 );
 AvatarImage.displayName = 'AvatarImage';
 
-const AvatarFallback = React.forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
-  ({ className, ...props }, ref) => (
+interface AvatarFallbackProps extends React.HTMLAttributes<HTMLSpanElement> {
+  color?: string;
+}
+const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallbackProps>(
+  ({ className, color, style, ...props }, ref) => (
     <span
       ref={ref}
+      style={{ ...style, backgroundColor: color }}
       className={cn(
         'flex h-full w-full items-center justify-center rounded-full bg-gray-100 text-sm font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300',
         className

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -25,7 +25,9 @@ export function Header() {
         <DropdownMenu>
           <DropdownMenuTrigger className="rounded-full">
             <Avatar>
-              <AvatarFallback>JD</AvatarFallback>
+              <AvatarFallback color="#2563eb" className="text-white">
+                JD
+              </AvatarFallback>
             </Avatar>
           </DropdownMenuTrigger>
           <DropdownMenuContent>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -48,7 +48,11 @@
             <span class="sr-only">Toggle menu</span>
           </button>
           <div class="ml-auto flex items-center gap-6">
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4">

--- a/projects/detail.html
+++ b/projects/detail.html
@@ -49,7 +49,11 @@
           </button>
           <h1 class="text-xl font-semibold">Project Details</h1>
           <div class="ml-auto flex items-center gap-6">
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4 space-y-4">

--- a/projects/edit.html
+++ b/projects/edit.html
@@ -49,7 +49,11 @@
           </button>
           <h1 class="text-xl font-semibold">Edit Project</h1>
           <div class="ml-auto flex items-center gap-6">
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4 space-y-4">

--- a/projects/index.html
+++ b/projects/index.html
@@ -50,7 +50,11 @@
           <h1 class="text-xl font-semibold">Projects</h1>
           <div class="ml-auto flex items-center gap-6">
             <a href="#" class="inline-flex items-center justify-center rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-50 hover:bg-gray-900/90">Create a new project</a>
-            <div class="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-sm font-medium">JD</div>
+            <div class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full">
+              <span class="flex h-full w-full items-center justify-center rounded-full text-sm font-medium text-white" style="background-color:#2563eb;">
+                JD
+              </span>
+            </div>
           </div>
         </header>
         <main class="flex-1 p-4 space-y-4">


### PR DESCRIPTION
## Summary
- allow AvatarFallback to accept a custom color for the background
- style header user icon and static HTML templates with the Shadcn avatar markup and custom color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beef08e58c83258bd05b4512f70696