### PR TITLE
Add static index.html for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trackwork</title>
+  </head>
+  <body>
+    <h1>Trackwork</h1>
+    <p>Welcome to the Trackwork platform.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal `index.html` so GitHub Pages serves root content

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Type 'string | null | undefined' is not assignable to type 'string | undefined')*
- `npm run build` *(fails: Type 'string | null | undefined' is not assignable to type 'string | undefined')*


------
https://chatgpt.com/codex/tasks/task_e_68c5697344a8832593f9b178ce638cf5