### PR TITLE
Add placeholder client edit page for GitHub Pages

### DIFF
--- a/clients/edit.html
+++ b/clients/edit.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Edit Client</title>
+  </head>
+  <body>
+    <h1>Edit Client</h1>
+    <p id="message">Loading...</p>
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const id = params.get('id');
+      const message = id
+        ? `Editing client ${id} is not yet implemented. Please check back later.`
+        : 'No client specified.';
+      document.getElementById('message').textContent = message;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add static client edit page that reads `id` from URL and displays placeholder message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c56be7adc483258688d9c9d67e4e3b