### PR TITLE
fix: restore navigation access

### DIFF
--- a/app/clients/[id]/edit/edit-form.tsx
+++ b/app/clients/[id]/edit/edit-form.tsx
@@ -27,12 +27,12 @@ export default function EditForm({ client }: { client: Client }) {
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: {
-      name: client.name,
-      contact_person: client.contact_person,
-      email: client.email,
-      phone: client.phone,
-      company_name: client.company_name,
-      client_number: client.client_number,
+      name: client.name ?? '',
+      contact_person: client.contact_person ?? '',
+      email: client.email ?? '',
+      phone: client.phone ?? '',
+      company_name: client.company_name ?? '',
+      client_number: client.client_number ?? '',
     },
   });
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,26 +3,33 @@ import { cn } from '@/lib/utils';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'default' | 'outline' | 'ghost';
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'default', ...props }, ref) => {
+  ({ className, variant = 'default', asChild = false, children, ...props }, ref) => {
     const variantClasses =
       variant === 'outline'
         ? 'border border-input bg-background hover:bg-accent hover:text-accent-foreground'
         : variant === 'ghost'
         ? 'hover:bg-accent hover:text-accent-foreground'
         : 'bg-primary text-primary-foreground hover:bg-primary/90';
+    const classes = cn(
+      'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 h-9 px-4 py-2',
+      variantClasses,
+      className
+    );
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        className: cn(classes, (children as React.ReactElement).props.className),
+        ref,
+        ...props,
+      });
+    }
     return (
-      <button
-        ref={ref}
-        className={cn(
-          'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 h-9 px-4 py-2',
-          variantClasses,
-          className
-        )}
-        {...props}
-      />
+      <button ref={ref} className={classes} {...props}>
+        {children}
+      </button>
     );
   }
 );

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -17,7 +17,7 @@ export function Header() {
   const [open, setOpen] = React.useState(false);
   return (
     <header className="flex h-14 items-center border-b bg-white px-4 dark:border-gray-800 dark:bg-gray-950">
-      <Button variant="ghost" className="mr-2 md:hidden" onClick={() => setOpen(true)}>
+      <Button variant="ghost" className="mr-2" onClick={() => setOpen(true)}>
         <Menu className="h-5 w-5" />
         <span className="sr-only">Toggle menu</span>
       </Button>


### PR DESCRIPTION
## Summary
- keep navigation toggle always visible in the header
- allow Button component to render a child element via `asChild`
- guard client edit form defaults against null values

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c56d3063708325ad71a42121b7f353