### PR TITLE
Add mobile-friendly navigation across static pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-debug.log*
 yarn-error.log*
 .env
 .env.local
+tsconfig.tsbuildinfo

--- a/clients/edit.html
+++ b/clients/edit.html
@@ -4,10 +4,26 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Edit Client</title>
+    <link rel="stylesheet" href="../nav.css" />
   </head>
   <body>
+    <nav class="navbar">
+      <span class="nav-logo">Trackwork</span>
+      <button id="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+      <ul id="nav-menu" class="nav-menu">
+        <li><a href="/">Home</a></li>
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/clients/edit.html">Clients</a></li>
+        <li><a href="/projects">Projects</a></li>
+        <li><a href="/time">Time</a></li>
+        <li><a href="/invoices">Invoices</a></li>
+        <li><a href="/reports">Reports</a></li>
+        <li><a href="/settings">Settings</a></li>
+      </ul>
+    </nav>
     <h1>Edit Client</h1>
     <p id="message">Loading...</p>
+    <script src="../nav.js" defer></script>
     <script>
       const params = new URLSearchParams(window.location.search);
       const id = params.get('id');

--- a/index.html
+++ b/index.html
@@ -4,9 +4,25 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Trackwork</title>
+    <link rel="stylesheet" href="nav.css" />
   </head>
   <body>
+    <nav class="navbar">
+      <span class="nav-logo">Trackwork</span>
+      <button id="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
+      <ul id="nav-menu" class="nav-menu">
+        <li><a href="/">Home</a></li>
+        <li><a href="/dashboard">Dashboard</a></li>
+        <li><a href="/clients/edit.html">Clients</a></li>
+        <li><a href="/projects">Projects</a></li>
+        <li><a href="/time">Time</a></li>
+        <li><a href="/invoices">Invoices</a></li>
+        <li><a href="/reports">Reports</a></li>
+        <li><a href="/settings">Settings</a></li>
+      </ul>
+    </nav>
     <h1>Trackwork</h1>
     <p>Welcome to the Trackwork platform.</p>
+    <script src="nav.js" defer></script>
   </body>
 </html>

--- a/nav.css
+++ b/nav.css
@@ -1,0 +1,46 @@
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background-color: #ffffff;
+  border-bottom: 1px solid #e5e7eb;
+}
+.nav-logo {
+  font-weight: bold;
+}
+#nav-toggle {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+}
+.nav-menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: none;
+  flex-direction: column;
+}
+.nav-menu li {
+  margin: 0.5rem 0;
+}
+.nav-menu a {
+  color: #2563eb;
+  text-decoration: none;
+}
+.nav-menu.open {
+  display: flex;
+}
+@media (min-width: 640px) {
+  #nav-toggle {
+    display: none;
+  }
+  .nav-menu {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+  }
+  .nav-menu li {
+    margin: 0;
+  }
+}

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var toggle = document.getElementById('nav-toggle');
+  var menu = document.getElementById('nav-menu');
+  if (toggle && menu) {
+    toggle.addEventListener('click', function () {
+      menu.classList.toggle('open');
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add responsive navigation bar with hamburger menu
- include navigation on home and client edit pages
- ignore TypeScript build info file

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5727639788325972ebfa6d2d33f9f